### PR TITLE
Improve README.md: Start Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,21 @@ docker run -it -p 8888:8888 -p 6006:6006 -v ~/:/host waleedka/modern-deep-learni
 
 Note the *-v* option. It maps your user directory (~/) to /host in the container. Change it if needed. The two *-p* options expose the ports used by Jupyter Notebook and Tensorboard respectively.
 
-## Runing Jupyter Notebook
-While inside the Docker container (see previous section) run this command:
+## Running Jupyter Notebook
+
+**Important:** Do **not** run this on a public server accessible from the Internet. Security features have been disabled in the settings for convenience of local development.
+
+Start a Jupyter Notebook with one command:
+
+```bash
+docker run -it -p 8888:8888 -p 6006:6006 -v ~/:/root waleedka/modern-deep-learning jupyter notebook --ip=0.0.0.0 --allow-root --no-browser
+```
+
+This will use your user directory (~/) as `/root` directory in the container (where the notebook runs).
+
+Then, in your browser navigate to: http://localhost:8888/
+
+Another option is to start a command line and run a Jupyter notebook from there. While inside the Docker container (see previous section) run this command:
 
 ```bash
 cd /host    # So Jupyter Notebook uses this as it's root
@@ -43,5 +56,3 @@ jupyter notebook --allow-root
 ```
 
 Then, in your browser navigate to: http://localhost:8888/
-
-**Important:** Do **not** run this on a public server accessible from the Internet. Security features have been disabled in the settings for convenience of local development.


### PR DESCRIPTION
This improves the README/documentation of the docker container. It gives a one-liner on how to spin up a notebook without needing to interact with the container command line.